### PR TITLE
Completer function can return all emojis.

### DIFF
--- a/autoload/emoji.vim
+++ b/autoload/emoji.vim
@@ -85,7 +85,7 @@ function! emoji#complete(findstart, base)
   if a:findstart
     return match(getline('.')[0:col('.') - 1], ':[^: \t]*$')
   elseif empty(a:base)
-    return []
+    return s:emojis
   else
     augroup emoji_complete_redraw
       autocmd!


### PR DESCRIPTION
If the user types ":" and then calls emoji#complete, nothing will be
output, thus disabling completion mechanisms that attempt to cache the
whole completion function, such as YouCompleteMe.

As discussed in https://github.com/Valloric/YouCompleteMe/issues/1593,
this simple change enables the omnicomplete to return all completion
options available.
