### PR TITLE
emoji#complete: remove leading ':' when matching

### DIFF
--- a/autoload/emoji.vim
+++ b/autoload/emoji.vim
@@ -82,7 +82,7 @@ function! emoji#complete(findstart, base)
             \| augroup END
             \| augroup! emoji_complete_redraw
     augroup END
-    return filter(copy(s:emojis), 'stridx(v:val.word, a:base) >= 0')
+    return filter(copy(s:emojis), 'stridx(v:val.word, a:base[1:]) >= 0')
   endif
 endfunction
 


### PR DESCRIPTION
I have tried to complete ":*hea" initially, but that did not work.  When
looking at it I've found that it's the easiest for now to just remove the
initial ":" when comparing.

btw: I do not need the autocommands (`emoji_complete_redraw`) with Neovim and a patched rxvt-unicode.

Thanks for another nice plugin!  💜